### PR TITLE
chore: track external/ and add daily definitions workflow

### DIFF
--- a/.github/workflows/update-definitions.yml
+++ b/.github/workflows/update-definitions.yml
@@ -1,0 +1,41 @@
+name: Update Type Definitions
+
+on:
+  schedule:
+    - cron: "0 4 * * *" # Daily at 04:00 UTC on main
+  workflow_dispatch: # Runs on whichever branch is selected
+
+permissions:
+  contents: write
+
+jobs:
+  update-definitions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build (pulls latest type definitions via nibs-cli)
+        run: npm run build
+
+      - name: Commit updated definitions if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add external/
+          if git diff --cached --quiet; then
+            echo "No changes to external/ — skipping commit."
+          else
+            git commit -m "chore: update NovelAI type definitions"
+            git push origin HEAD
+          fi

--- a/.github/workflows/update-definitions.yml
+++ b/.github/workflows/update-definitions.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,6 @@ node_modules/
 # Build output (auto-generated, including tsconfig.json for IDE type hints)
 dist/
 
-# External type definitions (auto-downloaded)
-external/
-
 # IDE
 .vscode/
 .idea/


### PR DESCRIPTION
- Remove external/ from .gitignore so type definitions can be committed
- Add update-definitions workflow that runs on a daily cron (main) and
  workflow_dispatch (any branch); builds via nibs-cli which fetches the
  latest NovelAI script type definitions, then commits external/ if changed

https://claude.ai/code/session_014XhHEbT213nc3xgH8G9sCa