### PR TITLE
fix: replace kse-stub sentinel with name-based stub key detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.1] - 2026-02-27
+
+### Fixed
+
+- **Stub keys** — SEGA's lorebook content stage now inserts a single stub key equal to the entry's lowercased display name, replacing the old `["kse-stub", ...nameWords]` pattern. This removes the internal `kse-stub` sentinel from the visible lorebook UI and eliminates spurious one- or two-letter keys that could appear when a title contained short words. `findEntryNeedingKeys` now detects stubs by checking for exactly one key matching the entry's own name.
+
 ## [0.8.0] - 2026-02-26
 
 ### Added

--- a/src/core/store/effects/handlers/lorebook.ts
+++ b/src/core/store/effects/handlers/lorebook.ts
@@ -87,14 +87,14 @@ export const lorebookContentHandler: GenerationHandlers<LorebookContentTarget> =
         text: finalContent,
       });
 
-      // Insert stub keys so the entry activates in story text immediately.
-      // Stage 7 (keys) will replace these with map-informed proper keys.
-      // "kse-stub" sentinel lets findEntryNeedingKeys detect stub entries.
+      // Insert a stub key so the entry activates in story text immediately.
+      // Stage 7 (keys) will replace this with map-informed proper keys.
+      // The stub is just the lowercased entry name; findEntryNeedingKeys
+      // detects stubs by checking for a single key equal to the display name.
       const lorebookEntry = await api.v1.lorebook.entry(entryId);
-      const stubNameWords = (lorebookEntry?.displayName || "")
-        .toLowerCase()
+      const stubKey = (lorebookEntry?.displayName || "").toLowerCase();
       await api.v1.lorebook.updateEntry(entryId, {
-        keys: ["kse-stub", ...stubNameWords],
+        keys: [stubKey],
       });
 
       // Update draft with full content if viewing this entry

--- a/src/core/store/effects/sega.ts
+++ b/src/core/store/effects/sega.ts
@@ -195,8 +195,9 @@ async function findEntryNeedingReconciliation(state: RootState): Promise<DulfsIt
 
 /**
  * Find the next DULFS entry that needs keys generation.
- * Includes entries with no keys AND entries with only stub keys ("kse-stub"),
- * which were inserted by the content handler as placeholders.
+ * Includes entries with no keys AND entries with only a stub key (a single key
+ * equal to the entry's lowercased display name), which was inserted by the
+ * content handler as a placeholder.
  */
 async function findEntryNeedingKeys(state: RootState): Promise<DulfsItem | null> {
   const needsKeys: DulfsItem[] = [];
@@ -207,7 +208,9 @@ async function findEntryNeedingKeys(state: RootState): Promise<DulfsItem | null>
     for (const item of items) {
       const entry = await api.v1.lorebook.entry(item.id);
       if (!entry?.text?.trim()) continue;
-      const isStub = entry.keys?.includes("kse-stub") ?? false;
+      const isStub =
+        entry.keys?.length === 1 &&
+        entry.keys[0] === (entry.displayName || "").toLowerCase();
       if (!isStub && entry.keys && entry.keys.length > 0) continue;
       needsKeys.push(item);
     }


### PR DESCRIPTION
- Stub key is now just the lowercased entry display name (single key),
  removing the awkward "kse-stub" sentinel from the lorebook UI
- Eliminates word-splitting of the title, which could produce many
  short (1–2 letter) keys from names with short words
- findEntryNeedingKeys detects stubs by checking for exactly one key
  equal to the entry's lowercased display name

https://claude.ai/code/session_015jdzafCsqBNhDsH8A3Abfq