### PR TITLE
ci: build dev pre-release on pull requests, skip forks

### DIFF
--- a/.github/workflows/cleanup-prereleases.yml
+++ b/.github/workflows/cleanup-prereleases.yml
@@ -1,0 +1,33 @@
+name: Cleanup Pre-Releases
+
+on:
+  schedule:
+    # 03:00 UTC daily
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete all but the latest pre-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mapfile -t TAGS < <(gh release list --limit 1000 \
+            --json tagName,isPrerelease,createdAt \
+            --jq 'map(select(.isPrerelease)) | sort_by(.createdAt) | reverse | .[].tagName')
+          if [ "${#TAGS[@]}" -le 1 ]; then
+            echo "Nothing to clean (${#TAGS[@]} prerelease(s) present)."
+            exit 0
+          fi
+          echo "Keeping latest prerelease: ${TAGS[0]}"
+          for tag in "${TAGS[@]:1}"; do
+            echo "Deleting $tag"
+            gh release delete "$tag" --yes --cleanup-tag
+          done

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,6 +12,15 @@ on:
       - "package.json"
       - "package-lock.json"
       - "tsconfig.json"
+  pull_request:
+    paths:
+      - "src/**"
+      - "lib/**"
+      - "external/**"
+      - "project.yaml"
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig.json"
   workflow_dispatch:
 
 permissions:
@@ -19,10 +28,15 @@ permissions:
 
 jobs:
   build-and-prerelease:
+    # Fork PRs can't create tags/releases in the base repo and must not run with
+    # `contents: write` against untrusted code.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -37,6 +51,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Filter is scoped to v${VERSION}-dev.N, so the counter resets to 1
+          # whenever project.yaml's version changes.
           LAST_N=$(git ls-remote --tags origin \
             | awk '{print $2}' \
             | sed 's|refs/tags/||' \
@@ -68,4 +84,4 @@ jobs:
             --title "Pre-release v${FULL_VERSION}" \
             --prerelease \
             --generate-notes \
-            --target "${{ github.sha }}"
+            --target "${{ github.event.pull_request.head.sha || github.sha }}"


### PR DESCRIPTION
Adds a pull_request trigger to the Pre-Release workflow so dev builds
happen automatically for in-repo PRs. Fork PRs are skipped to avoid
running the contents:write job against untrusted code and because they
can't push tags anyway. Checkout and release --target use the PR head
SHA rather than the generated merge commit.

The dev counter is already scoped per ${VERSION} via the tag grep, so it
resets whenever project.yaml bumps; a short comment now documents that.