### PR TITLE
fix: lorebook prefill starts with bare name, matching templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.2] - 2026-04-24
+
+### Fixed
+
+- **Lorebook entries now open with the bare entity name on the first line**, matching the per-category templates (`[Entry Name]` / `Type: …` / `Setting: …`). The prefill previously prepended a redundant `Name:` label that didn't match the template, causing the model to drift into a freeform header instead of following the template.
+
 ## [0.11.1] - 2026-04-24
 
 ### Fixed
 
 - **Lorebook generation now respects the entity's selected type and typed name.** Previously a new world entity would generate as a Character regardless of the category picked in the edit pane, and the saved entry would be headed `Name: Unnamed Entry` if the user hadn't hit Save first. Name/category resolution now follows a **DRAFT > LOREBOOK > STATE** hierarchy, and the prefill written to the saved entry matches what was sent to the model.
-- **Lorebook entries now open with the bare entity name on the first line**, matching the per-category templates (`[Entry Name]` / `Type: …` / `Setting: …`). The prefill previously prepended a redundant `Name:` label that didn't match the template, causing the model to drift into a freeform header instead of following the template.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - **Lorebook generation now respects the entity's selected type and typed name.** Previously a new world entity would generate as a Character regardless of the category picked in the edit pane, and the saved entry would be headed `Name: Unnamed Entry` if the user hadn't hit Save first. Name/category resolution now follows a **DRAFT > LOREBOOK > STATE** hierarchy, and the prefill written to the saved entry matches what was sent to the model.
+- **Lorebook entries now open with the bare entity name on the first line**, matching the per-category templates (`[Entry Name]` / `Type: …` / `Setting: …`). The prefill previously prepended a redundant `Name:` label that didn't match the template, causing the model to drift into a freeform header instead of following the template.
 
 ### Changed
 

--- a/project.yaml
+++ b/project.yaml
@@ -6,7 +6,7 @@ createdAt: 1765374901
 author: Keilla
 description: A helper for writing stories
 memoryLimit: 8
-updatedAt: 1777019793
+updatedAt: 1777047924
 config:
   - name: xialong_mode
     prettyName: Xialong Mode

--- a/project.yaml
+++ b/project.yaml
@@ -1,12 +1,12 @@
 compatibilityVersion: naiscript-1.0
 id: e6c35faa-e4f2-4c3b-af4a-d56e4c992d87
 name: Story Engine
-version: 0.11.1
+version: 0.11.2
 createdAt: 1765374901
 author: Keilla
 description: A helper for writing stories
 memoryLimit: 8
-updatedAt: 1777047924
+updatedAt: 1777049542
 config:
   - name: xialong_mode
     prettyName: Xialong Mode

--- a/src/core/generation-journal.ts
+++ b/src/core/generation-journal.ts
@@ -72,16 +72,17 @@ const SEGA_LABELS =
 
 /**
  * Extract the entity name from the assistant prefill message, if present.
- * Lorebook content/keys factories end with an assistant prefill:
- *   "Name: Elspeth Wren\nType: Character\nSetting: ..."
- * Returns the name portion, or null if not found.
+ * Lorebook content/keys factories end with an assistant prefill whose first
+ * line is the bare entity name, followed by "Type:" on the next line:
+ *   "Elspeth Wren\nType: Character\nSetting: ..."
+ * Returns the first line when a "Type:" line follows, or null otherwise.
  */
 function extractEntityName(
   messages: { role: string; content?: string }[],
 ): string | null {
   const prefill = [...messages].reverse().find((m) => m.role === "assistant");
   if (!prefill?.content) return null;
-  const match = prefill.content.match(/^Name:\s*(.+)/m);
+  const match = prefill.content.match(/^(.+)\n\s*Type:/);
   return match?.[1]?.trim() ?? null;
 }
 

--- a/src/core/utils/lorebook-strategy.ts
+++ b/src/core/utils/lorebook-strategy.ts
@@ -218,7 +218,7 @@ export const createLorebookContentFactory = (
     await appendXialongStyleMessage(messages, XIALONG_STYLE.lorebookContent);
 
     // --- MSG 7: Anchored prefill ---
-    const assistantPrefill = `Name: ${displayName}\nType: ${entryType}\nSetting: ${setting || "original"}\n`;
+    const assistantPrefill = `${displayName}\nType: ${entryType}\nSetting: ${setting || "original"}\n`;
     messages.push({ role: "assistant", content: assistantPrefill });
 
     const xialong = await isXialongMode();
@@ -329,7 +329,7 @@ export const createLorebookRefineFactory = (
     const template = CATEGORY_TEMPLATES[categoryName] || "";
 
     // Anchored assistant prefill
-    const prefillContent = `Name: ${displayName}
+    const prefillContent = `${displayName}
 Type: ${entryType}
 Setting: ${setting}
 `;
@@ -423,7 +423,7 @@ export const buildLorebookPrefill = async (
     (await api.v1.storyStorage.get(STORAGE_KEYS.SETTING)) || "",
   );
 
-  return `Name: ${displayName}
+  return `${displayName}
 Type: ${entryType}
 Setting: ${setting}
 `;


### PR DESCRIPTION
The per-category templates (`[Entry Name]` / `Type: …` / `Setting: …`)
expect the first line to be just the name. The assistant prefill was
prepending `Name:`, which didn't match the template and encouraged the
model to produce a freeform header instead of following the template's
attribute lines.

Drop the `Name:` prefix from all three prefill callsites
(createLorebookContentFactory, createLorebookRefineFactory,
buildLorebookPrefill) and update the generation-journal extractor to
read the name from the first line instead of a `Name:` match.

https://claude.ai/code/session_013whvVr8pjHadvtSQaajhN1