### PR TITLE
fix: forge prompt explicitly treats brainstorm as creation source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.3] - 2026-04-27
+
+### Fixed
+
+- **Forge now reliably creates world entries for elements described in the Brainstorm.** The forge prompt previously only described how to treat the `=== ESTABLISHED WORLD ===` section, leaving the model to infer how to handle `=== BRAINSTORM ===`. With declarative-present-tense brainstorm summaries, GLM 4.6 in particular tended to read the brainstorm as existing world and only reference its elements in other entries instead of CREATEing them. The system prompt now explicitly identifies the brainstorm as source material to extract elements from, while keeping the established-world guard so re-Forges and in-progress stories don't recreate entities that already exist.
+
 ## [0.11.2] - 2026-04-24
 
 ### Fixed

--- a/project.yaml
+++ b/project.yaml
@@ -1,7 +1,7 @@
 compatibilityVersion: naiscript-1.0
 id: e6c35faa-e4f2-4c3b-af4a-d56e4c992d87
 name: Story Engine
-version: 0.11.2
+version: 0.11.3
 createdAt: 1765374901
 author: Keilla
 description: A helper for writing stories

--- a/src/core/utils/prompts.ts
+++ b/src/core/utils/prompts.ts
@@ -489,7 +489,8 @@ EXAMPLE:
 [THREAD "Black-Market Bay" | "Mira Voss", "The Sunken Arcade" | The physical space that makes Mira's work possible and visible to the wrong people.]
 [CRITIQUE | The cast has friction but the locations are generic containers — they need to be sites of specific pressure, not just backdrop. The arcade works; the hospital does not yet.]
 
-The ESTABLISHED WORLD section lists what already exists — do not recreate those elements.
+The === BRAINSTORM === section is source material — extract characters, locations, factions, systems, situations, and topics from it and CREATE them as world elements.
+The === ESTABLISHED WORLD === section lists elements that already exist — do not recreate those elements, even if the brainstorm describes them.
 The prior command sequence shows what has been built this pass — continue it naturally.`;
 
 


### PR DESCRIPTION
The forge system prompt only described how to handle ESTABLISHED WORLD,
leaving the model to infer how to treat the BRAINSTORM section. With
declarative-present-tense brainstorm summaries, GLM 4.6 read the
brainstorm as existing world and referenced its elements in other
entries without ever emitting CREATE commands for them.

Add an explicit instruction that BRAINSTORM is source material to
extract elements from, while keeping the ESTABLISHED guard so re-Forges
and in-progress stories don't recreate already-cast entities. Section
references in the prompt now use the same `=== … ===` markers that the
forge strategy actually injects.

https://claude.ai/code/session_01PjuzwoVg3pgnnB1YDuJ7mv