### PR TITLE
Fix manual continuation in brainstorm chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.4] - 2026-05-28
+
+### Fixed
+
+- **Manual continuation works again in the brainstorm chat.** Clicking Send with an empty input — the gesture for "keep going from where you stopped," useful when a long generation hits the 2048-token cap or wraps short of a natural ending — was a no-op: the submit effect bailed early whenever the last message wasn't from the user. Empty sends on an assistant-tail message now extend that message in place. The strategy keeps the existing assistant turn as the transcript tail (so the model literally continues it), seeds `accumulatedText` from the live message content via `prefillBehavior: "keep"`, and skips both the fresh chat-style prefill and the short-response retry (whose reset path would otherwise erase the original turn).
+
 ## [0.12.3] - 2026-05-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- **Manual continuation works again in the brainstorm chat.** Clicking Send with an empty input — the gesture for "keep going from where you stopped," useful when a long generation hits the 2048-token cap or wraps short of a natural ending — was a no-op: the submit effect bailed early whenever the last message wasn't from the user. Empty sends on an assistant-tail message now extend that message in place. The strategy keeps the existing assistant turn as the transcript tail (so the model literally continues it), seeds `accumulatedText` from the live message content via `prefillBehavior: "keep"`, and skips both the fresh chat-style prefill and the short-response retry (whose reset path would otherwise erase the original turn).
+- **Manual continuation works again in the brainstorm chat.** Clicking Send with an empty input — the gesture for "keep going from where you stopped," useful when a long generation gets cut off or wraps short of a natural ending — was a no-op: the submit effect bailed early whenever the last message wasn't from the user. Empty sends on an assistant-tail message now extend that message in place. The strategy keeps the existing assistant turn as the transcript tail (so the model literally continues it), seeds `accumulatedText` from the live message content via `prefillBehavior: "keep"`, and skips both the fresh chat-style prefill and the short-response retry (whose reset path would otherwise erase the original turn).
+
+### Changed
+
+- **Brainstorm and summary chats auto-continue when truncated.** The single-call budget was 1024 tokens, which was both prone to blocking on a full token-budget bucket and not enough room for a long, deliberate brainstorm answer. Initial requests now ask for 512 tokens — small enough to clear the bucket reliably — and the engine's existing continuation loop is wired up via `continuation: { maxCalls: 5 }` on the saved-chat strategy. If the model stops on `length` / `max_tokens`, up to five follow-up calls extend the same assistant turn, approximating the throughput of a single 2048-token request without forcing the user to manually re-send. The engine's continuation calls no longer override `max_tokens` — they inherit the strategy's value, so each continuation is the same size as the initial chunk.
 
 ## [0.12.3] - 2026-05-27
 

--- a/project.yaml
+++ b/project.yaml
@@ -6,7 +6,7 @@ createdAt: 1765374901
 author: Keilla
 description: A helper for writing stories
 memoryLimit: 8
-updatedAt: 1779974478
+updatedAt: 1779976474
 config:
   - name: xialong_mode
     prettyName: Xialong Mode

--- a/project.yaml
+++ b/project.yaml
@@ -1,12 +1,12 @@
 compatibilityVersion: naiscript-1.0
 id: e6c35faa-e4f2-4c3b-af4a-d56e4c992d87
 name: Story Engine
-version: 0.12.3
+version: 0.12.4
 createdAt: 1765374901
 author: Keilla
 description: A helper for writing stories
 memoryLimit: 8
-updatedAt: 1779968373
+updatedAt: 1779974478
 config:
   - name: xialong_mode
     prettyName: Xialong Mode

--- a/src/core/store/effects/chat-effects.ts
+++ b/src/core/store/effects/chat-effects.ts
@@ -48,7 +48,7 @@ async function submitChatGeneration(
     dispatch(messageRemoved({ chatId: chat.id, id: assistantId }));
     return;
   }
-  const params = await buildModelParams({ max_tokens: 1024, temperature: 1.0 });
+  const params = await buildModelParams({ max_tokens: 512, temperature: 1.0 });
   dispatch(
     requestQueued({
       id: strategy.requestId,

--- a/src/core/store/effects/chat-effects.ts
+++ b/src/core/store/effects/chat-effects.ts
@@ -84,15 +84,24 @@ export function registerChatEffects(
         );
       }
       const chat = findChat(latest(), chatId);
-      if (!chat || chat.messages.at(-1)?.role !== "user") return;
-      const assistantId = api.v1.uuid();
-      dispatch(
-        messageAdded({
-          chatId,
-          message: { id: assistantId, role: "assistant", content: "" },
-        }),
-      );
-      await submitChatGeneration(latest, dispatch, chat, assistantId);
+      const last = chat?.messages.at(-1);
+      if (!chat || !last) return;
+      if (last.role === "user") {
+        const assistantId = api.v1.uuid();
+        dispatch(
+          messageAdded({
+            chatId,
+            message: { id: assistantId, role: "assistant", content: "" },
+          }),
+        );
+        await submitChatGeneration(latest, dispatch, chat, assistantId);
+        return;
+      }
+      // Empty send on an assistant tail = manual continuation: extend the
+      // existing message in place instead of opening a new turn.
+      if (last.role === "assistant" && !text.trim()) {
+        await submitChatGeneration(latest, dispatch, chat, last.id);
+      }
     },
   );
 

--- a/src/core/store/effects/generation-engine.ts
+++ b/src/core/store/effects/generation-engine.ts
@@ -338,7 +338,7 @@ export function registerGenerationEngineEffects(
 
           const contResult = await genX.generate(
             continuationMessages,
-            { ...apiParams, taskId: contTaskId, max_tokens: 1024 },
+            { ...apiParams, taskId: contTaskId },
             onStream,
             "background",
             await api.v1.createCancellationSignal(),

--- a/src/core/utils/chat-strategy.ts
+++ b/src/core/utils/chat-strategy.ts
@@ -74,11 +74,21 @@ export async function buildChatStrategy(
   const noopDispatch: AppDispatch = () => {};
   const ctx = { getState, dispatch: noopDispatch };
 
+  // Manual continuation: target points at an existing assistant message that
+  // already has content. Keep it as the tail of the transcript (the model
+  // will continue from there), skip the fresh spec prefill, and tell the
+  // engine to seed accumulatedText with the existing content via "keep".
+  const targetMsg = chat.messages.find((m) => m.id === assistantMessageId);
+  const isContinuation =
+    !!targetMsg && targetMsg.role === "assistant" && targetMsg.content.length > 0;
+
   const styleBlock = spec.xialongStyleFor?.(chat, ctx);
   const xialong = styleBlock ? await isXialongMode() : false;
-  const prefill = xialong && styleBlock
-    ? styleBlock
-    : spec.prefillFor?.(chat, ctx);
+  const prefill = isContinuation
+    ? undefined
+    : xialong && styleBlock
+      ? styleBlock
+      : spec.prefillFor?.(chat, ctx);
 
   return {
     requestId: `chat-${chat.id}-${assistantMessageId}`,
@@ -89,7 +99,7 @@ export async function buildChatStrategy(
         content: spec.systemPromptFor(chat, ctx),
       };
       const transcript: Message[] = chat.messages
-        .filter((m) => m.id !== assistantMessageId)
+        .filter((m) => isContinuation || m.id !== assistantMessageId)
         .map((m) => ({ role: m.role, content: m.content }));
       const messages = [...prefix];
       messages.push({ role: "system", content: "----" });
@@ -103,8 +113,10 @@ export async function buildChatStrategy(
       return { messages, params };
     },
     target: { type: "chat", chatId: chat.id, messageId: assistantMessageId },
-    prefillBehavior: "trim",
+    prefillBehavior: isContinuation ? "keep" : "trim",
     assistantPrefill: prefill,
-    minResponseLength: xialong ? 40 : undefined,
+    // Skip the short-response retry for continuations — its reset path clears
+    // the visible message and would erase the original turn we're extending.
+    minResponseLength: isContinuation ? undefined : xialong ? 40 : undefined,
   };
 }

--- a/src/core/utils/chat-strategy.ts
+++ b/src/core/utils/chat-strategy.ts
@@ -118,5 +118,10 @@ export async function buildChatStrategy(
     // Skip the short-response retry for continuations — its reset path clears
     // the visible message and would erase the original turn we're extending.
     minResponseLength: isContinuation ? undefined : xialong ? 40 : undefined,
+    // Auto-continue when the model hits max_tokens. Initial call is small
+    // (512) so it clears the token-budget bucket; up to 5 continuations
+    // approximate the throughput of a single 2048-token request without
+    // forcing the user to manually re-send to extend a truncated reply.
+    continuation: { maxCalls: 5 },
   };
 }

--- a/tests/core/utils/chat-strategy.test.ts
+++ b/tests/core/utils/chat-strategy.test.ts
@@ -42,6 +42,44 @@ describe("buildChatStrategy", () => {
     expect(strategy.requestId).toBe("refine-r1-asst");
   });
 
+  it("manual continuation: keeps the existing assistant tail and switches prefillBehavior to keep", async () => {
+    const assistantId = "asst-existing";
+    const existingContent = "Half-written reply that hit the token cap.";
+    const chat: Chat = {
+      id: "c-cont",
+      type: "brainstorm",
+      title: "x",
+      subMode: "cowriter",
+      messages: [
+        { id: "u1", role: "user", content: "go" },
+        { id: assistantId, role: "assistant", content: existingContent },
+      ],
+      seed: { kind: "blank" },
+    };
+    const getState = (() =>
+      ({
+        chat: { chats: [chat], activeChatId: chat.id, refineChat: null },
+        foundation: {},
+        world: { entitiesById: {}, entityIds: [] },
+        brainstorm: {
+          chats: [{ id: "b1", title: "Brainstorm", messages: [], mode: "cowriter" }],
+          currentChatIndex: 0,
+        },
+      }) as unknown as RootState);
+    const strategy = await buildChatStrategy(getState, chat, assistantId);
+    expect(strategy.prefillBehavior).toBe("keep");
+    expect(strategy.minResponseLength).toBeUndefined();
+    const built = await strategy.messageFactory!();
+    const messages = built.messages;
+    // The existing assistant message survives as the tail of the transcript.
+    const last = messages[messages.length - 1];
+    expect(last.role).toBe("assistant");
+    expect(last.content).toBe(existingContent);
+    // No second assistant turn (i.e. no fresh chat-style prefill) is appended.
+    const assistantTurns = messages.filter((m: Message) => m.role === "assistant");
+    expect(assistantTurns).toHaveLength(1);
+  });
+
   it("messageFactory produces system + transcript without the in-progress assistant message", async () => {
     const assistantId = "asst-pending";
     const chat: Chat = {

--- a/tests/core/utils/chat-strategy.test.ts
+++ b/tests/core/utils/chat-strategy.test.ts
@@ -19,6 +19,8 @@ describe("buildChatStrategy", () => {
     const strategy = await buildChatStrategy(getState, chat, "asst-id");
     expect(strategy.target).toEqual({ type: "chat", chatId: chat.id, messageId: "asst-id" });
     expect(strategy.requestId).toContain(chat.id);
+    // Saved chats auto-continue when the model hits max_tokens.
+    expect(strategy.continuation).toEqual({ maxCalls: 5 });
   });
 
   it("returns a chatRefine target with refineContext applied for a refine chat", async () => {


### PR DESCRIPTION
## Summary

Restore the "manual continuation" feature in the brainstorm chat, which allows users to extend a partially-generated assistant message by sending an empty input when generation hits the token cap or stops short of a natural ending.

## Changes

- **Chat effects** (`chat-effects.ts`): Modified the submit handler to detect when the last message is from the assistant with empty input, and call `submitChatGeneration` with the existing assistant message ID instead of creating a new turn.

- **Chat strategy** (`chat-strategy.ts`): Added logic to detect continuation mode (targeting an existing assistant message with content) and adjust behavior accordingly:
  - Skip the fresh chat-style prefill when continuing
  - Set `prefillBehavior: "keep"` to seed `accumulatedText` from the existing message content
  - Skip `minResponseLength` validation to avoid the short-response retry, whose reset path would erase the original turn being extended
  - Keep the existing assistant message in the transcript tail so the model literally continues from it

- **Tests** (`chat-strategy.test.ts`): Added comprehensive test case verifying that manual continuation preserves the existing assistant tail, switches to `prefillBehavior: "keep"`, and produces a single assistant turn (no fresh prefill appended).

- **Version bump** (`project.yaml`, `CHANGELOG.md`): Bumped to 0.12.4 with changelog entry documenting the fix.

## Implementation Details

The continuation detection hinges on checking whether the target assistant message already has content (`targetMsg.content.length > 0`). This distinguishes it from the normal flow where a fresh empty assistant message is created and then filled by generation. When continuing, the strategy filters the transcript to *include* the target message (rather than exclude it), allowing the model to see and extend the existing partial response.

https://claude.ai/code/session_01FCiq992WnGRKfFrHCdnhud